### PR TITLE
Allow specifying multiple `@Code` and `@Library` annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /out/
 /.idea/
 *.iml
+/nalim.jar

--- a/example/one/nalim/example/CpuId.java
+++ b/example/one/nalim/example/CpuId.java
@@ -1,0 +1,25 @@
+package one.nalim.example;
+
+import one.nalim.Arch;
+import one.nalim.Code;
+import one.nalim.Linker;
+import one.nalim.Os;
+
+public class CpuId {
+
+    @Code(
+            os = Os.WINDOWS,
+            arch = Arch.AMD64,
+            value = "4989D9 89D0 0FA2 418900 41895804 41894808 4189500C 4C89CB C3"
+    )
+    @Code(
+            os = Os.LINUX,
+            arch = Arch.AMD64,
+            value = "4889D7 89F0 4889DE 0FA2 8907 895F04 894F08 89570C 4889F3 C3"
+    )
+    private static native void cpuid(int func, int[] out);
+
+    static {
+        Linker.linkClass(CpuId.class);
+    }
+}

--- a/src/one/nalim/AnnotationUtil.java
+++ b/src/one/nalim/AnnotationUtil.java
@@ -1,0 +1,112 @@
+package one.nalim;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+final class AnnotationUtil {
+
+    private static final int MAX_SCORE = 3;
+    private static final int NO_MATCH = -1;
+
+    static Library findLibrary(AnnotatedElement element, Os expectedOs, Arch expectedArch) {
+        return find(
+                Library.class,
+                element.getAnnotation(LibrarySet.class),
+                element.getAnnotation(Library.class),
+                LibrarySet::value, Library::os, Library::arch,
+                expectedOs, expectedArch);
+    }
+
+    static Code findCode(Method method, Os expectedOs, Arch expectedArch) {
+        return find(
+                Code.class,
+                method.getAnnotation(CodeSet.class),
+                method.getAnnotation(Code.class),
+                CodeSet::value, Code::os, Code::arch,
+                expectedOs, expectedArch);
+    }
+
+    private static <T extends Annotation, U extends Annotation> U find(
+            Class<U> annotationType,
+            T containerAnnotation,
+            U annotation,
+            Function<T, U[]> annotationsExtractor,
+            Function<U, Os> osExtractor, Function<U, Arch> archExtractor,
+            Os expectedOs, Arch expectedArch) {
+
+        final U[] annotations;
+        if (containerAnnotation == null) {
+            if (annotation == null) {
+                return null;
+            }
+
+            annotations = (U[]) Array.newInstance(annotationType, 1);
+            annotations[0] = annotation;
+        } else {
+            annotations = annotationsExtractor.apply(containerAnnotation);
+            if (annotations == null || annotations.length == 0) {
+                return null;
+            }
+        }
+
+        // Find the best-matching annotation by comparing their scores.
+        U match = null;
+        int matchScore = -1;
+        for (final U a : annotations) {
+            final int score = score(
+                    expectedOs, expectedArch,
+                    osExtractor.apply(a), archExtractor.apply(a));
+
+            if (score > matchScore) {
+                match = a;
+                matchScore = score;
+                if (score >= MAX_SCORE) {
+                    break;
+                }
+            }
+        }
+
+        return match;
+    }
+
+    private static int score(Os expectedOs, Arch expectedArch, Os os, Arch arch) {
+        if (os == expectedOs) {
+            if (arch == expectedArch) {
+                // Both OS and arch were specified and both match.
+                return MAX_SCORE;
+            }
+
+            if (arch == Arch.UNSPECIFIED) {
+                // Only OS was specified and it matches.
+                return MAX_SCORE - 1;
+            }
+
+            // Both OS and arch were specified, but arch doesn't match.
+            return NO_MATCH;
+        }
+
+        if (os == Os.UNSPECIFIED) {
+            if (arch == expectedArch) {
+                // Only Arch was specified, and it matches.
+                return MAX_SCORE - 2;
+            }
+
+            if (arch == Arch.UNSPECIFIED) {
+                // Neither OS nor arch were specified.
+                return MAX_SCORE - 3;
+            }
+
+            // Only Arch was specified, but it doesn't match.
+            return NO_MATCH;
+        }
+
+        // OS was specified, but it doesn't match.
+        return NO_MATCH;
+    }
+
+    private AnnotationUtil() {
+    }
+}

--- a/src/one/nalim/Arch.java
+++ b/src/one/nalim/Arch.java
@@ -1,0 +1,29 @@
+package one.nalim;
+
+import java.util.Locale;
+
+public enum Arch {
+    UNSPECIFIED,
+    AMD64,
+    AARCH64,
+    RISCV64,
+    UNKNOWN;
+
+    static final Arch CURRENT;
+
+    static {
+        String arch = System.getProperty("os.arch").toLowerCase(Locale.US);
+        if (!arch.contains("64")) {
+            // Non-64bit architectures are unsupported.
+            CURRENT = UNKNOWN;
+        } else if (arch.contains("x86") || arch.contains("amd64")) {
+            CURRENT = AMD64;
+        } else if (arch.contains("aarch") || arch.contains("arm")) {
+            CURRENT = AARCH64;
+        } else if (arch.contains("riscv")) {
+            CURRENT = RISCV64;
+        } else {
+            CURRENT = UNKNOWN;
+        }
+    }
+}

--- a/src/one/nalim/CallingConvention.java
+++ b/src/one/nalim/CallingConvention.java
@@ -25,28 +25,24 @@ import jdk.vm.ci.runtime.JVMCI;
 
 import java.lang.annotation.Annotation;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 abstract class CallingConvention {
 
     static CallingConvention getInstance() {
-        String arch = System.getProperty("os.arch").toLowerCase();
-        if (!arch.contains("64")) {
-            throw new IllegalStateException("Unsupported architecture: " + arch);
-        }
-
-        if (arch.contains("aarch") || arch.contains("arm")) {
-            return new AArch64CallingConvention();
-        }
-
-        if (arch.contains("riscv")) {
-            return new RISCV64CallingConvention();
-        }
-
-        String os = System.getProperty("os.name").toLowerCase();
-        if (os.contains("windows")) {
-            return new AMD64WindowsCallingConvention();
-        } else {
-            return new AMD64LinuxCallingConvention();
+        switch (Arch.CURRENT) {
+            case AMD64:
+                if (Objects.requireNonNull(Os.CURRENT) == Os.WINDOWS) {
+                    return new AMD64WindowsCallingConvention();
+                }
+                return new AMD64LinuxCallingConvention();
+            case AARCH64:
+                return new AArch64CallingConvention();
+            case RISCV64:
+                return new RISCV64CallingConvention();
+            default:
+                throw new IllegalStateException(
+                        "Unsupported architecture: " + System.getProperty("os.arch"));
         }
     }
 

--- a/src/one/nalim/Code.java
+++ b/src/one/nalim/Code.java
@@ -19,6 +19,7 @@
 package one.nalim;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@Repeatable(CodeSet.class)
 public @interface Code {
     /**
      * Machine code for the method implementation
@@ -35,4 +37,18 @@ public @interface Code {
      * Typically, the code should end with a return instruction.
      */
     String value();
+
+    /**
+     * The operating system that will run the code specified in this annotation.
+     * When there are multiple {@link Code} annotations, the one with matching
+     * `os` attribute will have precedence over the one without it.
+     */
+    Os os() default Os.UNSPECIFIED;
+
+    /**
+     * The CPU architecture that will run the code specified in this annotation.
+     * When there are multiple {@link Code} annotations, the one with matching
+     * `arch` attribute will have precedence over the one without it.
+     */
+    Arch arch() default Arch.UNSPECIFIED;
 }

--- a/src/one/nalim/CodeSet.java
+++ b/src/one/nalim/CodeSet.java
@@ -1,0 +1,12 @@
+package one.nalim;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CodeSet {
+    Code[] value();
+}

--- a/src/one/nalim/Library.java
+++ b/src/one/nalim/Library.java
@@ -19,6 +19,7 @@
 package one.nalim;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,21 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
+@Repeatable(LibrarySet.class)
 public @interface Library {
     String value();
+
+    /**
+     * The operating system that will run the code specified in this annotation.
+     * When there are multiple {@link Library} annotations, the one with matching
+     * `os` attribute will have precedence over the one without it.
+     */
+    Os os() default Os.UNSPECIFIED;
+
+    /**
+     * The CPU architecture that will run the code specified in this annotation.
+     * When there are multiple {@link Library} annotations, the one with matching
+     * `arch` attribute will have precedence over the one without it.
+     */
+    Arch arch() default Arch.UNSPECIFIED;
 }

--- a/src/one/nalim/LibrarySet.java
+++ b/src/one/nalim/LibrarySet.java
@@ -1,0 +1,12 @@
+package one.nalim;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface LibrarySet {
+    Library[] value();
+}

--- a/src/one/nalim/Link.java
+++ b/src/one/nalim/Link.java
@@ -19,6 +19,7 @@
 package one.nalim;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;

--- a/src/one/nalim/Os.java
+++ b/src/one/nalim/Os.java
@@ -1,0 +1,26 @@
+package one.nalim;
+
+import java.util.Locale;
+
+public enum Os {
+    UNSPECIFIED,
+    LINUX,
+    MACOS,
+    WINDOWS,
+    UNKNOWN;
+
+    static final Os CURRENT;
+
+    static {
+        final String os = System.getProperty("os.name").toLowerCase(Locale.US);
+        if (os.contains("linux")) {
+            CURRENT = Os.LINUX;
+        } else if (os.contains("windows")) {
+            CURRENT = Os.WINDOWS;
+        } else if (os.contains("mac") || os.contains("darwin") || os.contains("os x")) {
+            CURRENT = Os.MACOS;
+        } else {
+            CURRENT = UNKNOWN;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

A user might want to use a different dynamic library or machine code depending on the current OS and architecture. Currently, such a user has to introduce a runtime check in a wrapper method, e.g.

```java
@Code("4D01C8 4989D9 89D0 0FA2 418900 41895804 41894808 4189500C 4C89CB C3")
private static native void cpuid_amd64_win(int func, int[] out, long out_base_offset);
@Code("488D3C11 89F0 4889DE 0FA2 8907 895F04 894F08 89570C 4889F3 C3")
private static native void cpuid_amd64_linux(int func, int[] out, long out_base_offset);

private static final boolean is_windows = System.getProperty("os.name").toLowerCase().contains("windows");

public static void cpuid(int func, int[] out) {
  if (is_windows) {
    cpuid_amd64_win(func, out, UNSAFE.ARRAY_INT_BASE_OFFSET);
  } else {
    cpuid_amd64_linux(func, out, UNSAFE.ARRAY_INT_BASE_OFFSET);
  }
}
```

We could improve the experience by allows a user specify multiple annotations with the desired OS and architecture combination.

Modifications:

- Added two new enums, `Os` and `Arch`, to represent the current and desired OS and architecture.
- Added `AnnotationUtil.findLibrary()` and `findCode()` that looks for the annotation that best-matches the expected OS and architecture.
- Updated `Linker` to use `AnnotationUtil` to find the right annotation.
- Updated `CallingConvention` to use `Os.CURRENT` and `Arch.CURRENT` to detect the current OS and architecture.
- Added the `CpuId` example that demonstrates this feature.

Result:

A user can now greatly simplify the above example:

```java
@Code(
  os = Os.WINDOWS,
  arch = Arch.AMD64,
  value = "4989D9 89D0 0FA2 418900 41895804 41894808 4189500C 4C89CB C3"
)
@Code(
  os = Os.LINUX,
  arch = Arch.AMD64,
  value = "4889D7 89F0 4889DE 0FA2 8907 895F04 894F08 89570C 4889F3 C3"
)
private static native void cpuid(int func, int[] out);
```

Closes #5